### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM google/dart
+
+RUN pub global activate linkcheck
+
+ENTRYPOINT ["/root/.pub-cache/bin/linkcheck"]

--- a/README.md
+++ b/README.md
@@ -136,6 +136,26 @@ export PATH="$PATH":"~/.pub-cache/bin"
 Then either restart the terminal or run `source ~/.bash_profile` (assuming
 `~/.bash_profile` is where you put the PATH export above).
 
+## Docker
+
+If you have Docker installed, you can build the image and use the container
+avoiding local Dart installation.
+
+#### Build
+
+```
+docker build -t filiph/linkcheck .
+```
+
+#### Usage (container mode)
+
+```
+docker run filiph/linkcheck <URL>
+```
+
+All bellow usage are valid running on container too.
+
+
 ## Usage
 
 If in doubt, run `linkcheck -h`. Here are some examples to get you started.


### PR DESCRIPTION
I've added a simple Dockerfile to execute the project.

The major justification is that I generally don't like to create all the setup of a project just to do a test or a simple use case.

Another great justification to have a Dockerfile is to prevent setup issues and have an alternative to run this project.

In my case, beyond of the setup usage, I want to put this project on my CD to do a post-deploy check of all the URLs of a staging project.