### PR TITLE
Add support for --connection-failures-as-warnings flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,26 @@
+## 2.0.6
+
+- Add support for `--connection-failures-as-warnings` flag.
+
+## 2.0.5
+
+- Fix checking of anchors containing non-ASCII chars.
+
 ## 2.0.4
 
 - Set min SDK to 2.0.0.
 
 ## 2.0.3
 
-- Add missing dependency on stream_channel
+- Add missing dependency on stream_channel.
 
 ## 2.0.2
 
-- Fix minor problems with Dart 2 upgrade
+- Fix minor problems with Dart 2 upgrade.
 
 ## 2.0.1
 
-- Set max SDK version to <3.0.0
+- Set max SDK version to <3.0.0.
 
 ## 2.0.0, 2.0.0+1
 
@@ -20,4 +28,4 @@
 
 ## 1.0.6
 
-- Last version compatible with Dart 1 and Dart 2
+- Last version compatible with Dart 1 and Dart 2.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linkcheck
-version: 2.0.5  # Don't forget to update in lib/linkcheck.dart, too.
+version: 2.0.6  # Don't forget to update in lib/linkcheck.dart, too.
 
 description: >
   A very fast link-checker. Crawls sites and checks integrity of links


### PR DESCRIPTION
Offers a solution to #29.

cc @kwalrath @sfshaza2