### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/src/worker/worker.dart
+++ b/lib/src/worker/worker.dart
@@ -78,7 +78,7 @@ Future<ServerInfoUpdate> checkServer(
     } else {
       decoder = utf8.decoder;
     }
-    content = await response.transform(decoder).join();
+    content = await response.cast<List<int>>().transform(decoder).join();
   } on FormatException {
     // TODO: report as a warning
     content = "";
@@ -151,7 +151,7 @@ Future<FetchResults> checkPage(
     } else {
       decoder = utf8.decoder;
     }
-    content = await response.transform(decoder).join();
+    content = await response.cast<List<int>>().transform(decoder).join();
   } on FormatException {
     // TODO: report as a warning
     checked.hasUnsupportedEncoding = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linkcheck
-version: 2.0.8  # Don't forget to update in lib/linkcheck.dart, too.
+version: 2.0.8+1  # Don't forget to update in lib/linkcheck.dart, too.
 
 description: >
   A very fast link-checker. Crawls sites and checks integrity of links


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900