### PR TITLE
Introduce flag to turn off reporting of missing anchors

### DIFF
--- a/lib/linkcheck.dart
+++ b/lib/linkcheck.dart
@@ -17,6 +17,7 @@ export 'src/link.dart' show Link;
 export 'src/origin.dart' show Origin;
 export 'src/writer_report.dart' show reportForWriters;
 
+const anchorFlag = "check-anchors";
 const ansiFlag = "nice";
 const connectionFailuresAsWarnings = "connection-failures-as-warnings";
 const debugFlag = "debug";
@@ -177,6 +178,8 @@ Future<int> run(List<String> arguments, Stdout stdout) async {
             "default, the tool only checks internal links.")
     ..addFlag(redirectFlag,
         help: "Also report all links that point at a redirected URL.")
+    ..addFlag(anchorFlag,
+        help: "Report links that point at a missing anchor.", defaultsTo: true)
     ..addSeparator("Advanced")
     ..addOption(inputFlag,
         abbr: 'i',
@@ -220,6 +223,7 @@ Future<int> run(List<String> arguments, Stdout stdout) async {
   bool verbose = argResults[debugFlag] == true;
   bool shouldCheckExternal = argResults[externalFlag] == true;
   bool showRedirects = argResults[redirectFlag] == true;
+  bool shouldCheckAnchors = argResults[anchorFlag] == true;
   String inputFile = argResults[inputFlag] as String;
   String skipFile = argResults[skipFlag] as String;
 
@@ -285,7 +289,7 @@ Future<int> run(List<String> arguments, Stdout stdout) async {
 
   var withWarning = result.links
       .where((link) =>
-          link.hasWarning ||
+          link.hasWarning(shouldCheckAnchors) ||
           reportConnectionFailuresAsWarnings && link.destination.didNotConnect)
       .length;
 
@@ -304,7 +308,8 @@ Future<int> run(List<String> arguments, Stdout stdout) async {
       print("Done crawling.                   ");
     }
 
-    reportForWriters(result, ansiTerm, showRedirects, stdout);
+    reportForWriters(
+        result, ansiTerm, shouldCheckAnchors, showRedirects, stdout);
 
     printStats(result, broken, withWarning, withInfo, withRedirects,
         showRedirects, ansiTerm, stdout);

--- a/lib/src/link.dart
+++ b/lib/src/link.dart
@@ -53,7 +53,8 @@ class Link {
 
   bool get hasInfo => destination.wasDeniedByRobotsTxt;
 
-  bool get hasWarning => breaksAnchor || destination.hasNoMimeType;
+  bool hasWarning(bool shouldCheckAnchors) =>
+      (shouldCheckAnchors && breaksAnchor) || destination.hasNoMimeType;
 
   Map<String, Object> toMap() => {
         "origin": origin.toMap(),

--- a/lib/src/writer_report.dart
+++ b/lib/src/writer_report.dart
@@ -11,8 +11,8 @@ import 'destination.dart';
 
 /// Writes the reports from the perspective of a website writer - which pages
 /// reference broken links.
-void reportForWriters(
-    CrawlResult result, bool ansiTerm, bool showRedirects, Stdout stdout) {
+void reportForWriters(CrawlResult result, bool ansiTerm,
+    bool shouldCheckAnchors, bool showRedirects, Stdout stdout) {
   void print(Object message) => stdout.writeln(message);
 
   print("");
@@ -25,7 +25,7 @@ void reportForWriters(
           (link.destination.isInvalid ||
               link.destination.wasTried &&
                   (link.destination.isBroken ||
-                      link.hasWarning ||
+                      link.hasWarning(shouldCheckAnchors) ||
                       link.destination.isRedirected)))
       .toList(growable: false);
 


### PR DESCRIPTION
On some websites, fragment identifiers are used for dynamic content or otherwise handled by client-side code. On these sites, the absence of an anchor tag with the fragment id is not necessarily an error.

Currently, linkcheck always reports these cases as warnings. 
This PR introduces a --[no-]check-anchors flag to turn off reporting of missing anchors. By default it enables the reporting, but it offers users the option to turn these warnings off. 