### PR TITLE
Add github action file

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,15 @@ docker run filiph/linkcheck <URL>
 
 All bellow usage are valid running on container too.
 
+#### Usage (github action)
 
+```
+uses: filiph/linkcheck-action@v1
+  with:
+    arguments: <URL>
+```
+
+All bellow usage are valid running as github action too.
 ## Usage
 
 If in doubt, run `linkcheck -h`. Here are some examples to get you started.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,12 @@
+name: 'linkcheck'
+description: 'Check links with filiph/linkcheck'
+inputs:
+  arguments:
+    description: 'Pass the linkchek arguments'
+    required: true
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.arguments }}


### PR DESCRIPTION
I think this is all you need to create a github action out of this.

As an alternative it would be possible to list all the arguments as github action arguments…
But doing it like this, it's easier to keep the action up to date and we keep the same interface which is already documented.

I created the action here: https://github.com/wunderundfitzig/linkcheck-action because I need to use it in a project.
I'm happy to hand over the repository if it would be better to keep the action in a seperate repo.
I would depricate that repo if a official action exists :-)

I guess this closes #46 