### PR TITLE
Improve behavior around `--show-redirects`

### DIFF
--- a/lib/linkcheck.dart
+++ b/lib/linkcheck.dart
@@ -298,7 +298,10 @@ Future<int> run(List<String> arguments, Stdout stdout) async {
   var withRedirects =
       result.links.where((link) => link.destination.isRedirected).length;
 
-  if (broken == 0 && withWarning == 0 && withInfo == 0) {
+  if (broken == 0 &&
+      withWarning == 0 &&
+      withInfo == 0 &&
+      (!showRedirects || withRedirects == 0)) {
     printStats(result, broken, withWarning, withInfo, withRedirects,
         showRedirects, ansiTerm, stdout);
   } else {

--- a/lib/linkcheck.dart
+++ b/lib/linkcheck.dart
@@ -320,7 +320,7 @@ Future<int> run(List<String> arguments, Stdout stdout) async {
   print("");
 
   if (broken > 0) return 2;
-  if (withWarning > 0) return 1;
+  if (withWarning > 0 || (showRedirects && withRedirects > 0)) return 1;
   return 0;
 }
 

--- a/lib/src/writer_report.dart
+++ b/lib/src/writer_report.dart
@@ -26,7 +26,7 @@ void reportForWriters(CrawlResult result, bool ansiTerm,
               link.destination.wasTried &&
                   (link.destination.isBroken ||
                       link.hasWarning(shouldCheckAnchors) ||
-                      link.destination.isRedirected)))
+                      (showRedirects && link.destination.isRedirected))))
       .toList(growable: false);
 
   List<Destination> deniedByRobots = result.destinations


### PR DESCRIPTION
PR #54 added a `--show-redirects` flag! But the implementation didn't seem quite complete: 

- It adds a redirects count to the summary, but it won't show the details about WHICH links were redirected
unless there was *also* at least one error or warning. So if you want to
actually update your redirected links, you need to temporarily break an
unrelated link first. 😆
- If you _didn't_ want info on redirects, you get spammed with it anyway whenever an unrelated error or warning triggers a full-detail report.
- Redirects aren't detectable in the exit code.

So, this PR has a commit to deal with each of those. 