### PR TITLE
Fix passing multiple arguments to github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.arguments }}
+  entrypoint:
+    ['sh', '-c', '/root/.pub-cache/bin/linkcheck ${{ inputs.arguments }}']


### PR DESCRIPTION
I messed up my original contribution… When one would pass more than one argument e.g. ` arguments: 'example.com  --skip-file skipfile.txt'` to the github action it would fail with:

```
FormatException: example.com%20--skipfile%20skipfile.txt is not a valid link-local address but contains %. Scope id should be used as part of link-local address. (at character 13) example.com%20--skipfile%20skipfile.txt
```

This is because github action arguments can only be strings, but when we pass them as `args` to the dockerfile the docker cmd looks like this: `cmd=["https://qa.ems.press --skipfile hui.txt"]`

The workaround I found is overwriting the docker `entrypoint` via the actions file. There I can just expand the `inputs.arguments` variable…

This should close #72