### PR TITLE
Add docker hub image to Readme?

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ on a Linux box, you might want to rename the executable to simply
 `linkcheck`, and move it to `/usr/local/bin`, `$HOME/bin` or another
 directory in your `$PATH`.
 
+### Docker image
+Latest executable in a [docker image](https://hub.docker.com/r/tennox/linkcheck):
+```
+docker run --rm tennox/linkcheck --help
+```
+(built from a [repo mirror](https://gitlab.com/txlab/docker-linkcheck) by @tennox)
+
 ### From Source
 
 #### Step 1. Install Dart


### PR DESCRIPTION
I love using your tool. Best I've found for the job! (and i tested 10+)

So I decided to set up a docker hub pipeline for it:
https://gitlab.com/txlab/docker-linkcheck
which deploys to:
https://hub.docker.com/r/tennox/linkcheck

Thought it might be a nice addition to the readme.
For transparency I tried to make it clear that it is built from a repo mirror by "someone else"