### PR TITLE
Draft new release to fix GH Action on Marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.21
+
+- Update ci.yml to latest Dart executables ([#92](https://github.com/filiph/linkcheck/pull/92))
+- Add docker hub image to Readme ([#91](https://github.com/filiph/linkcheck/pull/91)), Thanks Manuel ([@tennox](https://github.com/tennox))
+- Fix invalid syntax of github action file ([#90](https://github.com/filiph/linkcheck/pull/90)), Thanks Manuel ([@errnesto](https://github.com/errnesto))
+- Changed Dockerfile for cross-platform image building ([#88](https://github.com/filiph/linkcheck/pull/88)), Thanks Patrick ([@kastnerp](https://github.com/kastnerp))
+  
 ## 2.0.20
 
 - Fix passing multiple arguments to github action.

--- a/lib/linkcheck.dart
+++ b/lib/linkcheck.dart
@@ -28,7 +28,7 @@ const hostsFlag = "hosts";
 const inputFlag = "input-file";
 const redirectFlag = "show-redirects";
 const skipFlag = "skip-file";
-const version = "2.0.20";
+const version = "2.0.21";
 const versionFlag = "version";
 final _portOnlyRegExp = RegExp(r"^:\d+$");
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linkcheck
-version: 2.0.20 # Don't forget to update in lib/linkcheck.dart, too.
+version: 2.0.21 # Don't forget to update in lib/linkcheck.dart, too.
 
 description: >-
   A very fast link-checker. Crawls sites and checks integrity of links


### PR DESCRIPTION
Hi @filiph. I took a look and tried to help with making your tool accessible as predefined action for users to easily include in their workflows. This should probably fix the issues described in https://github.com/filiph/linkcheck/issues/93.

After recent updates from @errnesto tried to fix the action, there was still a release missing which included these changes/fixes.
The available version for easy consumption at the GitHub Actions Marketplace is pointing at the last available release still ([2.0.20](https://github.com/filiph/linkcheck/releases/tag/2.0.20) @ [Marketplace](https://github.com/marketplace/actions/check-links-with-linkcheck)), which does not contain those fixes yet. Hence a new, updated release is needed:
![Untitled](https://user-images.githubusercontent.com/9874850/167476109-95b76fa9-2415-4e94-8a1c-af0be8437204.png)

Changes:
- Updated changelog
- Incremented version number

If you want to change the wording or not include every PR in the changelog let me know or update my branch.

After merging this in, you would only need to tag a new release at the most recent commit on master and your release workflow should trigger and deploy a new version.
The GitHub Actions Marketplace should then pick it up as well and it should finally work. 👍 

Feel free to squash my commits on merge.