### PR TITLE
Migrate to null safety and support Dart 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
       - run: dart --version
-      - run: pub get
+      - run: dart pub get
       - run: dart analyze --fatal-warnings .
       - run: dart format --set-exit-if-changed .
       - run: dart run test -x integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
       - run: dart --version
-      - run: pub get
-      - run: pub global activate grinder
+      - run: dart pub get
+      - run: dart pub global activate grinder
       - run: echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
       - name: Package and publish
         run: grind pkg-github-all

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 # Files and directories created by pub
 .buildlog
 .dart_tool/
-.packages
 .project
 .pub/
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0
+
+- Require Dart 2.18 and support Dart 3
+- Rename library to `linkcheck` instead of `linkcheck.run`
+
 ## 2.0.23
 
 - Fix another issue with building artifacts through `grindr`/`cli_pkg`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Rename library to `linkcheck` instead of `linkcheck.run`
 - Update to the latest dependencies supporting sound null safety
 - Switch to Dart recommended lints (`package:lints/recommended.yaml`)
+- Use objects instead of maps to communicate between isolates
 
 ## 2.0.23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## 3.0.0
+## 3.0.0-dev
 
 - Require Dart 2.18 and support Dart 3
 - Rename library to `linkcheck` instead of `linkcheck.run`
+- Update to the latest dependencies supporting sound null safety
+- Switch to Dart recommended lints (`package:lints/recommended.yaml`)
 
 ## 2.0.23
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,6 @@ building binaries and placing a new release into
 [github.com/filiph/linkcheck/releases](https://github.com/filiph/linkcheck/releases).
 
 In order to populate it to the [GitHub Actions Marketplace](https://github.com/marketplace/actions/check-links-with-linkcheck)
-as well, it's currently requiered to manually <kbd>Edit</kbd> and hit 
+as well, it's currently required to manually <kbd>Edit</kbd> and hit 
 <kbd>Update release</kbd> on the release page once. No changes needed. 
 (Source: [GiHub Community](https://github.community/t/automatically-publish-action-to-marketplace-on-release/17978))

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,6 +10,7 @@ linter:
   rules:
     - always_declare_return_types
     - comment_references
+    - prefer_final_fields
     - type_annotate_public_apis
     - unawaited_futures
     - use_enums

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,4 +8,9 @@ analyzer:
 
 linter:
   rules:
-    prefer_single_quotes: false
+    - always_declare_return_types
+    - comment_references
+    - type_annotate_public_apis
+    - unawaited_futures
+    - use_enums
+    - use_super_parameters

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,11 +1,11 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
 
 linter:
   rules:
-    omit_local_variable_types: false # TODO: remove and fix
     prefer_single_quotes: false

--- a/bin/linkcheck.dart
+++ b/bin/linkcheck.dart
@@ -1,5 +1,3 @@
-library linkcheck.executable;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -2,5 +2,5 @@ tags:
   integration:
     skip: >
       The integration tests depend on serving the case folders, and for that
-      we need to know the path to those (which pub run test doesn't support).
-      Use `dart test/e2e_test.dart` to run these.
+      we need to know the path to those (which dart test doesn't support).
+      Use `dart run test/e2e_test.dart` to run these.

--- a/lib/linkcheck.dart
+++ b/lib/linkcheck.dart
@@ -26,7 +26,7 @@ const hostsFlag = "hosts";
 const inputFlag = "input-file";
 const redirectFlag = "show-redirects";
 const skipFlag = "skip-file";
-const version = "3.0.0";
+const version = "3.0.0-dev";
 const versionFlag = "version";
 final _portOnlyRegExp = RegExp(r"^:\d+$");
 

--- a/lib/linkcheck.dart
+++ b/lib/linkcheck.dart
@@ -1,14 +1,12 @@
-library linkcheck.run;
-
 import 'dart:async';
 import 'dart:io' hide Link;
 
 import 'package:args/args.dart';
 import 'package:console/console.dart';
 
-import 'package:linkcheck/src/parsers/url_skipper.dart';
 import 'src/crawl.dart' show crawl, CrawlResult;
 import 'src/link.dart' show Link;
+import 'src/parsers/url_skipper.dart';
 import 'src/writer_report.dart' show reportForWriters;
 
 export 'src/crawl.dart' show crawl, CrawlResult;
@@ -28,7 +26,7 @@ const hostsFlag = "hosts";
 const inputFlag = "input-file";
 const redirectFlag = "show-redirects";
 const skipFlag = "skip-file";
-const version = "2.0.23";
+const version = "3.0.0";
 const versionFlag = "version";
 final _portOnlyRegExp = RegExp(r"^:\d+$");
 
@@ -224,8 +222,8 @@ Future<int> run(List<String> arguments, Stdout stdout) async {
   bool shouldCheckExternal = argResults[externalFlag] == true;
   bool showRedirects = argResults[redirectFlag] == true;
   bool shouldCheckAnchors = argResults[anchorFlag] == true;
-  String inputFile = argResults[inputFlag] as String;
-  String skipFile = argResults[skipFlag] as String;
+  String? inputFile = argResults[inputFlag] as String?;
+  String? skipFile = argResults[skipFlag] as String?;
 
   List<String> urls = argResults.rest.toList();
   UrlSkipper skipper = UrlSkipper.empty();
@@ -261,7 +259,7 @@ Future<int> run(List<String> arguments, Stdout stdout) async {
   }
 
   // TODO: exit gracefully if provided URL isn't a parseable URI
-  List<Uri> uris = urls.map((url) => Uri.parse(url)).toList();
+  List<Uri> uris = urls.map((url) => Uri.parse(url)).toList(growable: false);
   Set<String> hosts;
   if ((argResults[hostsFlag] as Iterable<String>).isNotEmpty) {
     hosts = Set<String>.from(argResults[hostsFlag] as Iterable<String>);

--- a/lib/src/crawl.dart
+++ b/lib/src/crawl.dart
@@ -288,7 +288,7 @@ Future<CrawlResult> crawl(
     if (verbose) {
       count += 1;
       print("Done checking: $checked (${checked.statusDescription}) "
-          "=> ${result?.links?.length ?? 0} links");
+          "=> ${result.links.length} links");
       if (checked.isBroken) {
         print("- BROKEN");
       }
@@ -437,10 +437,7 @@ Future<CrawlResult> crawl(
   }
 
   // Fix links (dedupe destinations).
-  var urlMap = {
-    for (final destination in closed)
-      destination.url : destination
-  };
+  var urlMap = {for (final destination in closed) destination.url: destination};
   for (var link in links) {
     var canonical = urlMap[link.destination.url];
     // Note: If it wasn't for the possibility to SIGINT the process, we could

--- a/lib/src/crawl.dart
+++ b/lib/src/crawl.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'dart:io' show Stdout;
 
 import 'package:console/console.dart';
+import 'package:meta/meta.dart';
 
 import 'destination.dart';
 import 'link.dart';
@@ -472,9 +473,11 @@ Future<CrawlResult> crawl(
   return CrawlResult(links, closed);
 }
 
+@immutable
 class CrawlResult {
   final Set<Link> links;
   final Set<Destination> destinations;
+
   const CrawlResult(this.links, this.destinations);
 }
 

--- a/lib/src/crawl.dart
+++ b/lib/src/crawl.dart
@@ -260,7 +260,7 @@ Future<CrawlResult> crawl(
     if (destinations.isEmpty) {
       if (verbose) {
         print("WARNING: Received result for a destination that isn't in "
-            "the inProgress set: ${result.toMap()}");
+            "the inProgress set: $result");
         var isInOpen =
             open.where((dest) => dest.url == result.checked.url).isNotEmpty;
         var isInOpenExternal = openExternal

--- a/lib/src/crawl.dart
+++ b/lib/src/crawl.dart
@@ -1,5 +1,3 @@
-library linkcheck.crawl;
-
 import 'dart:async';
 import 'dart:collection';
 import 'dart:io' show Stdout;
@@ -8,11 +6,11 @@ import 'package:console/console.dart';
 
 import 'destination.dart';
 import 'link.dart';
-import 'package:linkcheck/src/parsers/url_skipper.dart';
-import 'uri_glob.dart';
+import 'parsers/url_skipper.dart';
 import 'server_info.dart';
-import 'worker/pool.dart';
+import 'uri_glob.dart';
 import 'worker/fetch_results.dart';
+import 'worker/pool.dart';
 
 /// Number of isolates to create by default.
 const defaultThreads = 8;
@@ -36,8 +34,8 @@ Future<CrawlResult> crawl(
   // Redirect output to injected [stdout] for better testing.
   void print(Object message) => stdout.writeln(message);
 
-  Cursor cursor;
-  TextPen pen;
+  Cursor? cursor;
+  TextPen? pen;
   if (ansiTerm) {
     Console.init();
     cursor = Cursor();
@@ -64,7 +62,9 @@ Future<CrawlResult> crawl(
         ..isSource = true
         ..isExternal = false)
       .toSet());
-  open.forEach((destination) => bin[destination.url] = Bin.open);
+  for (var destination in open) {
+    bin[destination.url] = Bin.open;
+  }
 
   // Queue for the external destinations.
   Queue<Destination> openExternal = Queue<Destination>();
@@ -106,7 +106,7 @@ Future<CrawlResult> crawl(
 
   int count = 0;
   if (!verbose) {
-    if (ansiTerm) {
+    if (cursor != null) {
       cursor.write("Crawling: $count");
     } else {
       print("Crawling...");
@@ -116,12 +116,12 @@ Future<CrawlResult> crawl(
   // TODO:
   // - --cache for creating a .linkcheck.cache file
 
-  var allDone = Completer<Null>();
+  var allDone = Completer<void>();
 
   // Respond to Ctrl-C
-  StreamSubscription stopSignalSubscription;
+  late final StreamSubscription<void> stopSignalSubscription;
   stopSignalSubscription = stopSignal.listen((dynamic _) async {
-    if (ansiTerm) {
+    if (pen != null) {
       pen
           .text("\n")
           .red()
@@ -148,11 +148,11 @@ Future<CrawlResult> crawl(
       }
     }
 
-    bool _serverIsKnown(Destination destination) =>
+    bool serverIsKnown(Destination destination) =>
         servers.keys.contains(destination.uri.authority);
 
     Iterable<Destination> availableDestinations =
-        _zip(open.where(_serverIsKnown), openExternal.where(_serverIsKnown));
+        _zip(open.where(serverIsKnown), openExternal.where(serverIsKnown));
 
     // In order not to touch the underlying iterables, we keep track
     // of the destinations we want to remove.
@@ -164,8 +164,8 @@ Future<CrawlResult> crawl(
       destinationsToRemove.add(destination);
 
       String host = destination.uri.authority;
-      ServerInfo server = servers[host];
-      if (server.hasNotConnected) {
+      ServerInfo? server = servers[host];
+      if (server == null || server.hasNotConnected) {
         destination.didNotConnect = true;
         closed.add(destination);
         bin[destination.url] = Bin.closed;
@@ -176,8 +176,9 @@ Future<CrawlResult> crawl(
         continue;
       }
 
-      if (server.bouncer != null &&
-          !server.bouncer.allows(destination.uri.path)) {
+      var serverBouncer = server.bouncer;
+      if (serverBouncer != null &&
+          !serverBouncer.allows(destination.uri.path)) {
         destination.wasDeniedByRobotsTxt = true;
         closed.add(destination);
         bin[destination.url] = Bin.closed;
@@ -236,7 +237,7 @@ Future<CrawlResult> crawl(
           "${result.didNotConnect ? 'didn\'t connect' : 'connected'}, "
           "${result.robotsTxtContents.isEmpty ? 'no robots.txt' : 'robots.txt found'}.");
     } else {
-      if (ansiTerm) {
+      if (cursor != null) {
         cursor.moveLeft(count.toString().length);
         count += 1;
         cursor.write(count.toString());
@@ -292,7 +293,7 @@ Future<CrawlResult> crawl(
         print("- BROKEN");
       }
     } else {
-      if (ansiTerm) {
+      if (cursor != null) {
         cursor.moveLeft(count.toString().length);
         count += 1;
         cursor.write(count.toString());
@@ -436,11 +437,13 @@ Future<CrawlResult> crawl(
   }
 
   // Fix links (dedupe destinations).
-  var urlMap = Map<String, Destination>.fromIterable(closed,
-      key: (Object dest) => (dest as Destination).url);
+  var urlMap = {
+    for (final destination in closed)
+      destination.url : destination
+  };
   for (var link in links) {
     var canonical = urlMap[link.destination.url];
-    // Note: If it wasn't for the posibility to SIGINT the process, we could
+    // Note: If it wasn't for the possibility to SIGINT the process, we could
     // assert there is exactly one Destination per URL. There might not be,
     // though.
     if (canonical != null) {

--- a/lib/src/destination.dart
+++ b/lib/src/destination.dart
@@ -1,6 +1,6 @@
 import 'dart:io' show ContentType, HttpClientResponse, RedirectInfo;
 
-import 'package:linkcheck/src/parsers/html.dart';
+import 'parsers/html.dart';
 
 /// RegExp for detecting URI scheme, such as `http:`, `mailto:`, etc.
 final _scheme = RegExp(r"$(\w[\w\-]*\w):");

--- a/lib/src/destination.dart
+++ b/lib/src/destination.dart
@@ -31,12 +31,6 @@ class BasicRedirectInfo {
   BasicRedirectInfo.from(RedirectInfo info)
       : url = info.location.toString(),
         statusCode = info.statusCode;
-
-  BasicRedirectInfo.fromMap(Map<String, Object?> map)
-      : url = map["url"] as String,
-        statusCode = map["statusCode"] as int;
-
-  Map<String, Object> toMap() => {"url": url, "statusCode": statusCode};
 }
 
 class Destination {
@@ -100,32 +94,6 @@ class Destination {
   Destination(Uri uri)
       : url = uri.removeFragment().toString(),
         _uri = uri.removeFragment();
-
-  factory Destination.fromMap(Map<String, Object?> map) {
-    var destination = Destination.fromString(map["url"] as String);
-    var primaryType = map['primaryType'] as String?;
-    var subType = map['subType'] as String?;
-    var contentType = primaryType == null || subType == null
-        ? null
-        : ContentType(primaryType, subType);
-    destination
-      ..statusCode = map["statusCode"] as int?
-      ..contentType = contentType
-      ..redirects = (map["redirects"] as List<Map<String, Object>>?)
-              ?.map(BasicRedirectInfo.fromMap)
-              .toList(growable: false) ??
-          const []
-      ..finalUrl = map["finalUrl"] as String?
-      ..isExternal = map["isExternal"] as bool? ?? true
-      ..isSource = map["isSource"] as bool? ?? false
-      ..anchors = map["anchors"] as List<String>? ?? const []
-      ..isInvalid = map["isInvalid"] as bool? ?? false
-      ..didNotConnect = map["didNotConnect"] as bool? ?? false
-      ..wasParsed = map["wasParsed"] as bool? ?? false
-      ..hasUnsupportedEncoding =
-          map["hasUnsupportedEncoding"] as bool? ?? false;
-    return destination;
-  }
 
   Destination.fromString(String url)
       : url = url.contains("#") ? url.split("#").first : url;
@@ -225,23 +193,6 @@ class Destination {
     return anchors.contains(normalizeAnchor(fragment));
   }
 
-  Map<String, Object?> toMap() => {
-        "url": url,
-        "statusCode": statusCode,
-        "primaryType": contentType?.primaryType,
-        "subType": contentType?.subType,
-        "redirects":
-            redirects.map((info) => info.toMap()).toList(growable: false),
-        "finalUrl": finalUrl,
-        "isExternal": isExternal,
-        "isSource": isSource,
-        "anchors": anchors,
-        "isInvalid": isInvalid,
-        "didNotConnect": didNotConnect,
-        "wasParsed": wasParsed,
-        "hasUnsupportedEncoding": hasUnsupportedEncoding
-      };
-
   @override
   String toString() => url;
 
@@ -282,36 +233,6 @@ class DestinationResult {
         isSource = destination.isSource,
         redirects = [],
         anchors = [];
-
-  DestinationResult.fromMap(Map<String, Object?> map)
-      : url = map["url"] as String,
-        finalUrl = map["finalUrl"] as String?,
-        statusCode = map["statusCode"] as int?,
-        primaryType = map["primaryType"] as String?,
-        subType = map["subType"] as String?,
-        redirects = (map["redirects"] as List<Map<String, Object>>)
-            .map((obj) => BasicRedirectInfo.fromMap(obj))
-            .toList(),
-        isSource = map["isSource"] as bool? ?? false,
-        anchors = map["anchors"] as List<String>? ?? const [],
-        didNotConnect = map["didNotConnect"] as bool? ?? false,
-        wasParsed = map["wasParsed"] as bool? ?? false,
-        hasUnsupportedEncoding =
-            map["hasUnsupportedEncoding"] as bool? ?? false;
-
-  Map<String, Object?> toMap() => {
-        "url": url,
-        "finalUrl": finalUrl,
-        "statusCode": statusCode,
-        "primaryType": primaryType,
-        "subType": subType,
-        "redirects": redirects.map((info) => info.toMap()).toList(),
-        "isSource": isSource,
-        "anchors": anchors,
-        "didNotConnect": didNotConnect,
-        "wasParsed": wasParsed,
-        "hasUnsupportedEncoding": hasUnsupportedEncoding
-      };
 
   void updateFromResponse(HttpClientResponse response) {
     statusCode = response.statusCode;

--- a/lib/src/destination.dart
+++ b/lib/src/destination.dart
@@ -32,7 +32,7 @@ class BasicRedirectInfo {
       : url = info.location.toString(),
         statusCode = info.statusCode;
 
-  BasicRedirectInfo.fromMap(Map<String, Object> map)
+  BasicRedirectInfo.fromMap(Map<String, Object?> map)
       : url = map["url"] as String,
         statusCode = map["statusCode"] as int;
 

--- a/lib/src/link.dart
+++ b/lib/src/link.dart
@@ -16,13 +16,6 @@ class Link {
       [this.wasSkipped = false])
       : fragment = fragment == null || fragment.isEmpty ? null : fragment;
 
-  Link.fromMap(Map<String, Object?> map)
-      : this(
-            Origin.fromMap(map["origin"] as Map<String, Object?>),
-            Destination.fromMap(map["destination"] as Map<String, Object?>),
-            map["destinationAnchor"] as String?,
-            map["wasSkipped"] as bool);
-
   bool get breaksAnchor =>
       !wasSkipped &&
       destination.wasParsed &&
@@ -53,13 +46,6 @@ class Link {
 
   bool hasWarning(bool shouldCheckAnchors) =>
       (shouldCheckAnchors && breaksAnchor) || destination.hasNoMimeType;
-
-  Map<String, Object?> toMap() => {
-        "origin": origin.toMap(),
-        "destination": destination.toMap(),
-        "destinationAnchor": fragment,
-        "wasSkipped": wasSkipped
-      };
 
   @override
   String toString() => "$origin => $destination"

--- a/lib/src/link.dart
+++ b/lib/src/link.dart
@@ -1,12 +1,10 @@
-library linkcheck.link;
-
 import 'package:linkcheck/src/destination.dart';
 import 'package:linkcheck/src/origin.dart';
 
 class Link {
-  Origin origin;
+  final Origin origin;
   Destination destination;
-  String fragment;
+  final String? fragment;
 
   /// Whether or not this link was marked as skipped.
   ///
@@ -14,7 +12,7 @@ class Link {
   /// has a match, [wasSkipped] will be `true`.
   bool wasSkipped = false;
 
-  Link(this.origin, this.destination, String fragment,
+  Link(this.origin, this.destination, String? fragment,
       [this.wasSkipped = false])
       : fragment = fragment == null || fragment.isEmpty ? null : fragment;
 
@@ -56,7 +54,7 @@ class Link {
   bool hasWarning(bool shouldCheckAnchors) =>
       (shouldCheckAnchors && breaksAnchor) || destination.hasNoMimeType;
 
-  Map<String, Object> toMap() => {
+  Map<String, Object?> toMap() => {
         "origin": origin.toMap(),
         "destination": destination.toMap(),
         "destinationAnchor": fragment,
@@ -65,6 +63,6 @@ class Link {
 
   @override
   String toString() => "$origin => $destination"
-      "${fragment == null ? '' : '#' + fragment} "
+      "${fragment == null ? '' : '#$fragment'} "
       "(${destination.statusDescription})";
 }

--- a/lib/src/link.dart
+++ b/lib/src/link.dart
@@ -1,5 +1,5 @@
-import 'package:linkcheck/src/destination.dart';
-import 'package:linkcheck/src/origin.dart';
+import 'destination.dart';
+import 'origin.dart';
 
 class Link {
   final Origin origin;

--- a/lib/src/link.dart
+++ b/lib/src/link.dart
@@ -16,11 +16,11 @@ class Link {
       [this.wasSkipped = false])
       : fragment = fragment == null || fragment.isEmpty ? null : fragment;
 
-  Link.fromMap(Map<String, Object> map)
+  Link.fromMap(Map<String, Object?> map)
       : this(
-            Origin.fromMap(map["origin"] as Map<String, Object>),
-            Destination.fromMap(map["destination"] as Map<String, Object>),
-            map["destinationAnchor"] as String,
+            Origin.fromMap(map["origin"] as Map<String, Object?>),
+            Destination.fromMap(map["destination"] as Map<String, Object?>),
+            map["destinationAnchor"] as String?,
             map["wasSkipped"] as bool);
 
   bool get breaksAnchor =>

--- a/lib/src/origin.dart
+++ b/lib/src/origin.dart
@@ -11,7 +11,7 @@ class Origin {
 
   Origin(this.uri, this.span, this.tagName, this.text, this.outerHtml);
 
-  Origin.fromMap(Map<String, Object> map)
+  Origin.fromMap(Map<String, Object?> map)
       : this(
             Uri.parse(map["uri"] as String),
             _deserializeSpan(map["span"] as Map<String, Object>),

--- a/lib/src/origin.dart
+++ b/lib/src/origin.dart
@@ -1,7 +1,9 @@
+import 'package:meta/meta.dart';
 import 'package:source_span/source_span.dart';
 
 /// Origin of a link. Contains information about the exact place in a file
 /// (URI) and some additional helpful info.
+@immutable
 class Origin {
   final Uri uri;
   final SourceSpan span;
@@ -12,5 +14,5 @@ class Origin {
   Origin(this.uri, this.span, this.tagName, this.text, this.outerHtml);
 
   @override
-  String toString() => "$uri (${span.start.line + 1}:${span.start.column})";
+  String toString() => '$uri (${span.start.line + 1}:${span.start.column})';
 }

--- a/lib/src/origin.dart
+++ b/lib/src/origin.dart
@@ -11,47 +11,6 @@ class Origin {
 
   Origin(this.uri, this.span, this.tagName, this.text, this.outerHtml);
 
-  Origin.fromMap(Map<String, Object?> map)
-      : this(
-            Uri.parse(map["uri"] as String),
-            _deserializeSpan(map["span"] as Map<String, Object>),
-            map["tagName"] as String,
-            map["text"] as String,
-            map["outerHtml"] as String);
-
   @override
   String toString() => "$uri (${span.start.line + 1}:${span.start.column})";
-
-  Map<String, Object> toMap() => {
-        "uri": uri.toString(),
-        "span": _serializeSpan(span),
-        "tagName": tagName,
-        "text": text,
-        "outerHtml": outerHtml
-      };
 }
-
-Map<String, Object> _serializeSpan(SourceSpan span) => {
-      "start": _serializeSourceLocation(span.start),
-      "end": _serializeSourceLocation(span.end),
-      "text": span.text
-    };
-
-SourceSpan _deserializeSpan(Map<String, Object> map) => SourceSpan(
-    _deserializeSourceLocation(map["start"] as Map<String, Object>),
-    _deserializeSourceLocation(map["end"] as Map<String, Object>),
-    map["text"] as String);
-
-Map<String, Object> _serializeSourceLocation(SourceLocation location) =>
-    <String, Object>{
-      "offset": location.offset,
-      "line": location.line,
-      "column": location.column,
-      "sourceUrl": location.sourceUrl.toString()
-    };
-
-SourceLocation _deserializeSourceLocation(Map<String, Object> map) =>
-    SourceLocation(map["offset"] as int,
-        sourceUrl: Uri.parse(map["sourceUrl"] as String),
-        line: map["line"] as int,
-        column: map["column"] as int);

--- a/lib/src/origin.dart
+++ b/lib/src/origin.dart
@@ -1,5 +1,3 @@
-library linkcheck.source;
-
 import 'package:source_span/source_span.dart';
 
 /// Origin of a link. Contains information about the exact place in a file

--- a/lib/src/parsers/html.dart
+++ b/lib/src/parsers/html.dart
@@ -1,5 +1,3 @@
-import 'dart:html';
-
 import 'package:html/dom.dart';
 import 'package:html/parser.dart';
 
@@ -115,7 +113,7 @@ FetchResults parseHtml(String content, Uri uri, Destination current,
   Uri baseUri = current.finalUri;
   var baseElements = doc.querySelectorAll("base[href]");
   if (baseElements.isNotEmpty) {
-    var firstBaseHref = (baseElements.first as BaseElement?)?.href;
+    var firstBaseHref = baseElements.first.attributes["href"];
 
     if (firstBaseHref != null) {
       // More than one base element per page is not according to HTML specs.
@@ -134,7 +132,7 @@ FetchResults parseHtml(String content, Uri uri, Destination current,
       .map((element) => extractLink(current.finalUri, baseUri, element,
           const ["href", "src"], currentDestinations,
           parseable: true))
-      .toList(growable: false);
+      .toList();
 
   // Find resources
   var resourceElements =

--- a/lib/src/parsers/html.dart
+++ b/lib/src/parsers/html.dart
@@ -107,7 +107,7 @@ FetchResults parseHtml(String content, Uri uri, Destination current,
 
   if (ignoreLinks) {
     checked.wasParsed = true;
-    return FetchResults(checked, const []);
+    return FetchResults(checked);
   }
 
   Uri baseUri = current.finalUri;

--- a/lib/src/parsers/robots_txt.dart
+++ b/lib/src/parsers/robots_txt.dart
@@ -1,5 +1,3 @@
-library linkcheck.parsers.robots_txt;
-
 class RobotsBouncer {
   /// The shortest possible identifying part of the user agent.
   ///
@@ -12,8 +10,6 @@ class RobotsBouncer {
       : robotName = forRobot {
     const userAgentString = "User-agent:";
     const disallowString = "Disallow:";
-
-    assert(robotName != null);
 
     Set<String> currentUserAgents = {};
     Set<String> currentPaths = {};

--- a/lib/src/parsers/robots_txt.dart
+++ b/lib/src/parsers/robots_txt.dart
@@ -1,3 +1,6 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class RobotsBouncer {
   /// The shortest possible identifying part of the user agent.
   ///
@@ -60,9 +63,11 @@ class RobotsBouncer {
   }
 }
 
+@immutable
 class _Rule {
   final Set<String> userAgents;
   final Set<String> paths;
+
   _Rule(this.userAgents, this.paths);
 
   // 'Disallow:' (with empty rulepath) means something like 'allow all'

--- a/lib/src/parsers/url_skipper.dart
+++ b/lib/src/parsers/url_skipper.dart
@@ -1,5 +1,3 @@
-library linkcheck.parsers.url_skipper;
-
 const _commentStart = "#";
 
 const _commentStartEscape = r"\#";
@@ -7,7 +5,7 @@ const _commentStartEscape = r"\#";
 /// Parses and keeps record of the URL patterns to skip.
 class UrlSkipper {
   /// Path of the provided file with regexps to skip.
-  final String path;
+  final String? path;
 
   final List<_UrlSkipperRecord> _records;
 
@@ -40,7 +38,7 @@ class UrlSkipper {
   }
 
   static Iterable<_UrlSkipperRecord> _parse(Iterable<String> lines) sync* {
-    int lineNumber = 1;
+    var lineNumber = 1;
     for (var line in lines) {
       line = line.trim();
 

--- a/lib/src/server_info.dart
+++ b/lib/src/server_info.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import 'parsers/robots_txt.dart';
 
 const robotName = "linkcheck";
@@ -106,6 +108,7 @@ class ServerInfo {
 }
 
 /// To be sent from Worker to main thread.
+@immutable
 class ServerInfoUpdate {
   final String host;
   final bool didNotConnect;

--- a/lib/src/server_info.dart
+++ b/lib/src/server_info.dart
@@ -116,9 +116,9 @@ class ServerInfoUpdate {
 
   ServerInfoUpdate.didNotConnect(String host) : this(host, didNotConnect: true);
 
-  ServerInfoUpdate.fromMap(Map<String, Object> map)
+  ServerInfoUpdate.fromMap(Map<String, Object?> map)
       : this(map["host"] as String,
-            robotsTxtContents: ["robots"] as String,
+            robotsTxtContents: map["robots"] as String,
             didNotConnect: map["didNotConnect"] as bool);
 
   Map<String, Object> toMap() => {

--- a/lib/src/server_info.dart
+++ b/lib/src/server_info.dart
@@ -115,15 +115,4 @@ class ServerInfoUpdate {
       {this.robotsTxtContents = '', this.didNotConnect = false});
 
   ServerInfoUpdate.didNotConnect(String host) : this(host, didNotConnect: true);
-
-  ServerInfoUpdate.fromMap(Map<String, Object?> map)
-      : this(map["host"] as String,
-            robotsTxtContents: map["robots"] as String,
-            didNotConnect: map["didNotConnect"] as bool);
-
-  Map<String, Object> toMap() => {
-        "host": host,
-        "robots": robotsTxtContents,
-        "didNotConnect": didNotConnect
-      };
 }

--- a/lib/src/uri_glob.dart
+++ b/lib/src/uri_glob.dart
@@ -1,6 +1,8 @@
 import 'package:glob/glob.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart';
 
+@immutable
 class UriGlob {
   static final _urlContext = Context(style: Style.url);
 

--- a/lib/src/uri_glob.dart
+++ b/lib/src/uri_glob.dart
@@ -1,5 +1,3 @@
-library linkcheck.uri_glob;
-
 import 'package:glob/glob.dart';
 import 'package:path/path.dart';
 

--- a/lib/src/worker/fetch_options.dart
+++ b/lib/src/worker/fetch_options.dart
@@ -1,5 +1,3 @@
-library linkcheck.fetch_options;
-
 import 'dart:async';
 
 import '../uri_glob.dart';

--- a/lib/src/worker/fetch_options.dart
+++ b/lib/src/worker/fetch_options.dart
@@ -9,7 +9,7 @@ class FetchOptions {
   final headIncompatible = <String>{}; // TODO: send to main
   // TODO: hashmap of known problematic servers etc. = List<String,ServerInfo>
 
-  final StreamSink<Map<String, Object>> _sink;
+  final StreamSink<WorkerTask> _sink;
 
   FetchOptions(this._sink);
 
@@ -20,7 +20,7 @@ class FetchOptions {
   }
 
   void info(String message) {
-    _sink.add(<String, Object>{verbKey: infoFromWorkerVerb, dataKey: message});
+    _sink.add(WorkerTask(verb: WorkerVerb.infoFromWorker, data: message));
   }
 
   /// Returns true if the provided [uri] should be considered internal. This

--- a/lib/src/worker/fetch_results.dart
+++ b/lib/src/worker/fetch_results.dart
@@ -1,5 +1,3 @@
-library linkcheck.fetch_results;
-
 import '../destination.dart';
 import '../link.dart';
 

--- a/lib/src/worker/fetch_results.dart
+++ b/lib/src/worker/fetch_results.dart
@@ -8,13 +8,14 @@ class FetchResults {
 
   FetchResults.fromMap(Map<String, Object> map)
       : this(
-            DestinationResult.fromMap(map["checked"] as Map<String, Object>),
-            List<Link>.from((map["links"] as List<Map>).map<Link>(
+            DestinationResult.fromMap(
+                map["checked"] as Map<String, Object>? ?? const {}),
+            List<Link>.from((map["links"] as List<Map>? ?? const []).map<Link>(
                 (serialization) =>
                     Link.fromMap(serialization as Map<String, Object>))));
 
   Map<String, Object> toMap() => {
         "checked": checked.toMap(),
-        "links": links?.map((link) => link.toMap())?.toList() ?? <Object>[]
+        "links": links.map((link) => link.toMap()).toList(growable: false)
       };
 }

--- a/lib/src/worker/fetch_results.dart
+++ b/lib/src/worker/fetch_results.dart
@@ -6,13 +6,13 @@ class FetchResults {
   final List<Link> links;
   FetchResults(this.checked, this.links);
 
-  FetchResults.fromMap(Map<String, Object> map)
+  FetchResults.fromMap(Map<String, Object?> map)
       : this(
             DestinationResult.fromMap(
-                map["checked"] as Map<String, Object>? ?? const {}),
+                map["checked"] as Map<String, Object?>? ?? {}),
             List<Link>.from((map["links"] as List<Map>? ?? const []).map<Link>(
-                (serialization) =>
-                    Link.fromMap(serialization as Map<String, Object>))));
+                (serialization) => Link.fromMap(
+                    serialization as Map<String, Object?> ?? {}))));
 
   Map<String, Object> toMap() => {
         "checked": checked.toMap(),

--- a/lib/src/worker/fetch_results.dart
+++ b/lib/src/worker/fetch_results.dart
@@ -5,7 +5,7 @@ class FetchResults {
   final DestinationResult checked;
   final List<Link> links;
 
-  FetchResults(this.checked, this.links);
+  FetchResults(this.checked, [this.links = const []]);
 
   @override
   String toString() {

--- a/lib/src/worker/fetch_results.dart
+++ b/lib/src/worker/fetch_results.dart
@@ -4,18 +4,11 @@ import '../link.dart';
 class FetchResults {
   final DestinationResult checked;
   final List<Link> links;
+
   FetchResults(this.checked, this.links);
 
-  FetchResults.fromMap(Map<String, Object?> map)
-      : this(
-            DestinationResult.fromMap(
-                map["checked"] as Map<String, Object?>? ?? {}),
-            List<Link>.from((map["links"] as List<Map>? ?? const []).map<Link>(
-                (serialization) =>
-                    Link.fromMap(serialization as Map<String, Object?>))));
-
-  Map<String, Object> toMap() => {
-        "checked": checked.toMap(),
-        "links": links.map((link) => link.toMap()).toList(growable: false)
-      };
+  @override
+  String toString() {
+    return 'FetchResults{checked: $checked, links: $links}';
+  }
 }

--- a/lib/src/worker/fetch_results.dart
+++ b/lib/src/worker/fetch_results.dart
@@ -11,8 +11,8 @@ class FetchResults {
             DestinationResult.fromMap(
                 map["checked"] as Map<String, Object?>? ?? {}),
             List<Link>.from((map["links"] as List<Map>? ?? const []).map<Link>(
-                (serialization) => Link.fromMap(
-                    serialization as Map<String, Object?> ?? {}))));
+                (serialization) =>
+                    Link.fromMap(serialization as Map<String, Object?>))));
 
   Map<String, Object> toMap() => {
         "checked": checked.toMap(),

--- a/lib/src/worker/pool.dart
+++ b/lib/src/worker/pool.dart
@@ -88,7 +88,6 @@ class Pool {
       await worker.kill();
     }));
     _finished = true;
-    _workers.clear();
   }
 
   /// Finds the worker with the least amount of jobs.

--- a/lib/src/worker/pool.dart
+++ b/lib/src/worker/pool.dart
@@ -88,6 +88,7 @@ class Pool {
       await worker.kill();
     }));
     _finished = true;
+    _workers.clear();
   }
 
   /// Finds the worker with the least amount of jobs.

--- a/lib/src/worker/pool.dart
+++ b/lib/src/worker/pool.dart
@@ -148,9 +148,9 @@ class Pool {
             // Only notify about the failed destination when the old
             // worker is gone. Otherwise, crawl could fail to wrap up, thinking
             // that one Worker is still working.
-            var checked = DestinationResult.fromDestination(destination);
-            checked.didNotConnect = true;
-            var result = FetchResults(checked, const []);
+            var checked = DestinationResult.fromDestination(destination,
+                didNotConnect: true);
+            var result = FetchResults(checked);
             _fetchResultsSink.add(result);
           }
 

--- a/lib/src/worker/worker.dart
+++ b/lib/src/worker/worker.dart
@@ -245,7 +245,7 @@ class Worker {
   StreamSink<Map<String, Object>> _sink;
   Stream<Map<String, Object>> _stream;
 
-  String name;
+  final String name;
 
   Destination? destinationToCheck;
 
@@ -254,6 +254,9 @@ class Worker {
   bool _spawned = false;
 
   bool _isKilled = false;
+
+  Worker(this.name);
+
   bool get idle =>
       destinationToCheck == null &&
       serverToCheck == null &&

--- a/lib/src/worker/worker.dart
+++ b/lib/src/worker/worker.dart
@@ -285,7 +285,3 @@ class Worker {
   @override
   String toString() => "Worker<$name>";
 }
-
-class _SpawnedWorker {
-
-}

--- a/lib/src/worker/worker.dart
+++ b/lib/src/worker/worker.dart
@@ -183,7 +183,7 @@ void worker(SendPort port) {
         return;
       case checkPageVerb:
         Destination destination =
-            Destination.fromMap(message[dataKey] as Map<String, Object>);
+            Destination.fromMap(message[dataKey] as Map<String, Object?>);
         var results = await checkPage(destination, client, options);
         if (alive) {
           sink.add({verbKey: checkPageDoneVerb, dataKey: results.toMap()});

--- a/lib/src/worker/worker.dart
+++ b/lib/src/worker/worker.dart
@@ -241,9 +241,7 @@ Future<StreamChannel<Map<String, Object>>> _spawnWorker() async {
 }
 
 class Worker {
-  StreamChannel<Map<String, Object>> _channel;
-  StreamSink<Map<String, Object>> _sink;
-  Stream<Map<String, Object>> _stream;
+  StreamChannel<Map<String, Object>>? _channel;
 
   final String name;
 
@@ -265,26 +263,27 @@ class Worker {
 
   bool get isKilled => _isKilled;
 
-  StreamSink<Map<String, Object>> get sink => _sink;
+  StreamSink<Map<String, Object>> get sink => _channel!.sink;
   bool get spawned => _spawned;
 
-  Stream<Map<String, Object>> get stream => _stream;
+  Stream<Map<String, Object>> get stream => _channel!.stream;
 
   Future<void> kill() async {
     if (!_spawned) return;
     _isKilled = true;
-    sink.add(dieMessage);
-    await sink.close();
+    var sinkToClose = sink;
+    sinkToClose.add(dieMessage);
+    await sinkToClose.close();
   }
 
   Future<void> spawn() async {
     assert(_channel == null);
     _channel = await _spawnWorker();
-    _sink = _channel.sink;
-    _stream = _channel.stream;
     _spawned = true;
   }
 
   @override
-  String toString() => "Worker<$name>";
+  String toString() => 'Worker<$name>';
 }
+
+class SpawnedWorker {}

--- a/lib/src/writer_report.dart
+++ b/lib/src/writer_report.dart
@@ -1,13 +1,11 @@
-library linkcheck.writer_report;
-
 import 'dart:io' show Stdout;
 import 'dart:math' show min;
 
 import 'package:console/console.dart';
 
 import 'crawl.dart' show CrawlResult;
-import 'link.dart';
 import 'destination.dart';
+import 'link.dart';
 
 /// Writes the reports from the perspective of a website writer - which pages
 /// reference broken links.
@@ -42,9 +40,9 @@ void reportForWriters(CrawlResult result, bool ansiTerm,
       .toList(growable: false);
   sourceUris.sort((a, b) => a.toString().compareTo(b.toString()));
 
-  TextPen pen;
+  TextPen? ansiPen;
   if (ansiTerm) {
-    pen = TextPen();
+    ansiPen = TextPen();
   }
 
   List<Destination> brokenSeeds = result.destinations
@@ -55,8 +53,8 @@ void reportForWriters(CrawlResult result, bool ansiTerm,
   if (brokenSeeds.isNotEmpty) {
     print("Provided URLs failing:");
     for (var destination in brokenSeeds) {
-      if (ansiTerm) {
-        pen
+      if (ansiPen != null) {
+        ansiPen
             .reset()
             .yellow()
             .text(destination.url)
@@ -80,8 +78,8 @@ void reportForWriters(CrawlResult result, bool ansiTerm,
     print("Access to these URLs denied by robots.txt, "
         "so we couldn't check them:");
     for (var destination in deniedByRobots) {
-      if (ansiTerm) {
-        pen
+      if (ansiPen != null) {
+        ansiPen
             .reset()
             .normal()
             .text("- ")
@@ -101,8 +99,8 @@ void reportForWriters(CrawlResult result, bool ansiTerm,
   // TODO: report invalid links
 
   for (var uri in sourceUris) {
-    if (ansiTerm) {
-      printWithAnsi(uri, problematic, pen);
+    if (ansiPen != null) {
+      printWithAnsi(uri, problematic, ansiPen);
     } else {
       printWithoutAnsi(uri, problematic, stdout);
     }
@@ -122,8 +120,8 @@ void reportForWriters(CrawlResult result, bool ansiTerm,
     brokenUris.sort((a, b) => a.toString().compareTo(b.toString()));
 
     for (var uri in brokenUris) {
-      if (ansiTerm) {
-        printWithAnsi(uri, broken, pen);
+      if (ansiPen != null) {
+        printWithAnsi(uri, broken, ansiPen);
       } else {
         printWithoutAnsi(uri, broken, stdout);
       }
@@ -192,11 +190,12 @@ void printWithoutAnsi(Uri uri, List<Link> broken, Stdout stdout) {
   var links = broken.where((link) => link.origin.uri == uri);
   for (var link in links) {
     String tag = _buildTagSummary(link);
+    var linkFragment = link.fragment;
     print("- (${link.origin.span.start.line + 1}"
         ":${link.origin.span.start.column}) "
         "$tag"
         "=> ${link.destination.url}"
-        "${link.fragment == null ? '' : '#' + link.fragment} "
+        "${linkFragment == null ? '' : '#$linkFragment'} "
         "(${link.destination.statusDescription}"
         "${!link.destination.isBroken && link.breaksAnchor ? ' but missing anchor' : ''}"
         ")");

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,456 +5,529 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "8c7478991c7bbde2c1e18034ac697723176a5d3e7e0ca06c7f9aed69b6f388d7"
+      url: "https://pub.dev"
     source: hosted
-    version: "22.0.0"
+    version: "51.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: "120fe7ce25377ba616bb210e7584983b163861f45d6ec446744d507e3943881b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "5.3.1"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: ed7cc591a948744994714375caf9a2ce89e1d82e8243997c8a2994d57181c212
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.3.5"
   args:
     dependency: "direct main"
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: b003c3098049a51720352d219b0bb5f219b60fbfb68e7a4748139a06a5676515
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.3.1"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.7.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   build_cli_annotations:
     dependency: transitive
     description:
       name: build_cli_annotations
-      url: "https://pub.dartlang.org"
+      sha256: b59d2769769efd6c9ff6d4c4cede0be115a566afc591705c2040b707534b1172
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.dartlang.org"
+      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: dd007e4fb8270916820a0d66e24f619266b60773cddd082c6439341645af2659
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   cli_pkg:
     dependency: "direct dev"
     description:
       name: cli_pkg
-      url: "https://pub.dartlang.org"
+      sha256: b564e39edc96126238c2f0371b2ef0420fc2633e6e0780c9eadd6d1ec21cbb96
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.6"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
-      url: "https://pub.dartlang.org"
+      sha256: "66f86e916d285c1a93d3b79587d94bd71984a66aac4ff74e524cfa7877f1395c"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.5"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   console:
     dependency: "direct main"
     description:
       name: console
-      url: "https://pub.dartlang.org"
+      sha256: e04e7824384c5b39389acdd6dc7d33f3efe6b232f6f16d7626f194f6a01ad69a
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: d2494157c32b303f47dedee955b1479f2979c4ff66934eb7c0def44fd9e0267a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   csslib:
     dependency: "direct main"
     description:
       name: csslib
-      url: "https://pub.dartlang.org"
+      sha256: b36c7f7e24c0bdf1bf9a3da461c837d1de64b9f8beb190c9011d8c72a3dfd745
+      url: "https://pub.dev"
     source: hosted
-    version: "0.17.0"
+    version: "0.17.2"
   dhttpd:
     dependency: "direct dev"
     description:
       name: dhttpd
-      url: "https://pub.dartlang.org"
+      sha256: e7e5735549acb0d1d7f5101281dac700e8a444e3563f9c212d16196dc40384f4
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.2.0"
   glob:
     dependency: "direct main"
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.1"
   grinder:
     dependency: "direct dev"
     description:
       name: grinder
-      url: "https://pub.dartlang.org"
+      sha256: b24948a441fc65d07bc8b219d7ee8d6cc0af4cdb13823e0d3be6d848eb787b04
+      url: "https://pub.dev"
     source: hosted
-    version: "0.9.0"
+    version: "0.9.2"
   html:
     dependency: "direct main"
     description:
       name: html
-      url: "https://pub.dartlang.org"
+      sha256: d9793e10dbe0e6c364f4c59bf3e01fb33a9b2a674bc7a1081693dba0614b6269
+      url: "https://pub.dev"
     source: hosted
-    version: "0.15.0"
+    version: "0.15.1"
   http:
     dependency: transitive
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.5"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "0d4c73c3653ab85bf696d51a9657604c900a370549196a91f33e4c39af760852"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: "3520fa844009431b5d4491a5a778603520cdc399ab3406332dcc50f93547258c"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.7.0"
+  lints:
+    dependency: "direct dev"
+    description:
+      name: lints
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   logging:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: c0bbfe94d46aedf9b8b3e695cf3bd48c8e14b35e3b2c639e0aa7755d589ba946
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.13"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: "52e38f7e1143ef39daf532117d6b8f8f617bf4bcd6044ed8c29040d20d269630"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   node_interop:
     dependency: transitive
     description:
       name: node_interop
-      url: "https://pub.dartlang.org"
+      sha256: "3af2420c728173806f4378cf89c53ba9f27f7f67792b898561bff9d390deb98e"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "8ebdbaa3b96d5285d068f80772390d27c21e1fa10fb2df6627b1b9415043608d"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   path:
     dependency: "direct main"
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
-  pedantic:
-    dependency: "direct dev"
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.1"
+    version: "1.8.3"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      url: "https://pub.dartlang.org"
+      sha256: "49392a45ced973e8d94a85fdb21293fbb40ba805fc49f2965101ae748a3683b4"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "5.1.0"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.6.2"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.3"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      sha256: "75f6614d6dde2dc68948dffbaa4fe5dae32cd700eb9fb763fe11dfb45a3c4d0a"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.1"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.4"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.3"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "490098075234dcedb83c5d949b4c93dad5e6b7702748de000be2b57b8e6b2427"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.11"
   source_span:
     dependency: "direct main"
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: "direct main"
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: a5fcd2d25eeadbb6589e80198a47d6a464ba3e2049da473943b8af9797900c2d
+      url: "https://pub.dev"
     source: hosted
-    version: "1.17.8"
+    version: "1.22.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.16"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "0ef9755ec6d746951ba0aabe62f874b707690b5ede0fecc818b138fcc9b14888"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.3.28"
+    version: "0.4.20"
   test_process:
     dependency: transitive
     description:
       name: test_process
-      url: "https://pub.dartlang.org"
+      sha256: b0e6702f58272d459d5b80b88696483f86eac230dab05ecf73d0662e305d005e
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.3"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: e7fb6c2282f7631712b69c19d1bff82f3767eea33a2321c14fa59ad67ea391c7
+      url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: "3a969ddcc204a3e34e863d204b29c0752716f78b6f9cc8235083208d268a4ccd"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.0"
   xml:
     dependency: transitive
     description:
       name: xml
-      url: "https://pub.dartlang.org"
+      sha256: "80d494c09849dc3f899d227a78c30c5b949b985ededf884cb3f3bcd39f4b447a"
+      url: "https://pub.dev"
     source: hosted
-    version: "5.1.2"
+    version: "5.4.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
+  dart: ">=2.18.0 <4.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -258,7 +258,7 @@ packages:
     source: hosted
     version: "0.12.13"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
@@ -437,26 +437,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: a5fcd2d25eeadbb6589e80198a47d6a464ba3e2049da473943b8af9797900c2d
+      sha256: "98403d1090ac0aa9e33dfc8bf45cc2e0c1d5c58d7cb832cee1e50bf14f37961d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.22.0"
+    version: "1.22.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: c9282698e2982b6c3817037554e52f99d4daba493e8028f8112a83d68ccd0b12
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.17"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0ef9755ec6d746951ba0aabe62f874b707690b5ede0fecc818b138fcc9b14888"
+      sha256: c9e4661a5e6285b795d47ba27957ed8b6f980fc020e98b218e276e88aff02168
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.20"
+    version: "0.4.21"
   test_process:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
   A very fast link-checker. Crawls sites and checks integrity of links
   both in HTML and in CSS.
 
-homepage: https://github.com/filiph/linkcheck
+repository: https://github.com/filiph/linkcheck
 
 environment:
   sdk: '>=2.18.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  args: ^2.0.0
+  args: ^2.2.0
   console: ^4.1.0
   csslib: ^0.17.0
-  glob: ^2.0.1
+  glob: ^2.1.0
   html: ^0.15.0
   meta: ^1.8.0
   path: ^1.8.0
@@ -24,7 +24,7 @@ dependencies:
 dev_dependencies:
   lints: ^2.0.1
   dhttpd: ^4.0.0
-  test: ^1.22.0
+  test: ^1.22.1
   cli_pkg: ^2.1.6
   grinder: ^0.9.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   csslib: ^0.17.0
   glob: ^2.0.1
   html: ^0.15.0
+  meta: ^1.8.0
   path: ^1.8.0
   source_span: ^1.8.0
   stream_channel: ^2.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linkcheck
-version: 3.0.0 # Don't forget to update in lib/linkcheck.dart, too.
+version: 3.0.0-dev # Don't forget to update in lib/linkcheck.dart, too.
 
 description: >-
   A very fast link-checker. Crawls sites and checks integrity of links

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linkcheck
-version: 2.0.23 # Don't forget to update in lib/linkcheck.dart, too.
+version: 3.0.0 # Don't forget to update in lib/linkcheck.dart, too.
 
 description: >-
   A very fast link-checker. Crawls sites and checks integrity of links
@@ -8,25 +8,24 @@ description: >-
 homepage: https://github.com/filiph/linkcheck
 
 environment:
-  sdk: '>=2.11.99 <3.0.0'
+  sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  args: '>=1.5.1 <3.0.0'
+  args: ^2.0.0
   console: ^4.1.0
   csslib: ^0.17.0
   glob: ^2.0.1
   html: ^0.15.0
-  logging: ^1.0.1
-  path: ^1.6.2
-  source_span: ^1.5.5
-  stream_channel: ^2.0.0
+  path: ^1.8.0
+  source_span: ^1.8.0
+  stream_channel: ^2.1.0
 
 dev_dependencies:
+  lints: ^2.0.1
   dhttpd: ^4.0.0
-  pedantic: ^1.7.0
-  test: ^1.6.3
-  cli_pkg: ^2.1.1
-  grinder: ^0.9.0
+  test: ^1.22.0
+  cli_pkg: ^2.1.6
+  grinder: ^0.9.2
 
 executables:
   linkcheck: linkcheck

--- a/test/e2e_test.dart
+++ b/test/e2e_test.dart
@@ -209,10 +209,10 @@ void main() {
   }, tags: ["integration"]);
 }
 
-var directory = path.absolute(path.dirname(scriptPath));
-var scriptPath = scriptUri.toFilePath();
+String directory = path.absolute(path.dirname(scriptPath));
+String scriptPath = scriptUri.toFilePath();
 
-var scriptUri = Platform.script;
+Uri scriptUri = Platform.script;
 
 String getServingPath(int caseNumber) =>
     path.join(directory, "case$caseNumber");
@@ -264,7 +264,7 @@ class _MockStdout implements Stdout {
   }
 
   @override
-  void addError(error, [StackTrace? stackTrace]) {
+  Never addError(Object error, [StackTrace? stackTrace]) {
     throw error;
 //    _sink.addError(error, stackTrace);
   }

--- a/test/e2e_test.dart
+++ b/test/e2e_test.dart
@@ -12,7 +12,7 @@ import 'package:test/test.dart';
 // Get the directory of the script being run.
 void main() {
   group("linkcheck e2e", () {
-    _MockStdout out;
+    late _MockStdout out;
     int port = 4321;
 
     setUp(() {
@@ -224,14 +224,14 @@ class _MockStdout implements Stdout {
   StringBuffer buf = StringBuffer();
 
   @override
-  final Encoding encoding = Encoding.getByName("utf-8");
+  final Encoding encoding = const Utf8Codec();
 
   _MockStdout() {
 //    _sink = _controller.sink;
   }
 
   @override
-  Future get done => throw UnimplementedError();
+  Never get done => throw UnimplementedError();
 
   @override
   set encoding(Encoding encoding) {
@@ -264,36 +264,36 @@ class _MockStdout implements Stdout {
   }
 
   @override
-  void addError(error, [StackTrace stackTrace]) {
+  void addError(error, [StackTrace? stackTrace]) {
     throw error;
 //    _sink.addError(error, stackTrace);
   }
 
   @override
-  Future addStream(Stream<List<int>> stream) => throw UnimplementedError();
+  Never addStream(Stream<List<int>> stream) => throw UnimplementedError();
 
   void clearOutput() {
     buf.clear();
   }
 
   @override
-  Future close() async {
+  Future<void> close() async {
 //    await _sink.close();
 //    await _controller.close();
   }
 
   @override
-  Future flush() => throw UnimplementedError();
+  Never flush() => throw UnimplementedError();
 
   @override
-  void write(Object object) {
+  void write(Object? object) {
     String string = '$object';
     buf.write(string);
   }
 
   @override
-  void writeAll(Iterable objects, [String sep = ""]) {
-    Iterator iterator = objects.iterator;
+  void writeAll(Iterable<dynamic> objects, [String sep = ""]) {
+    var iterator = objects.iterator;
     if (!iterator.moveNext()) return;
     if (sep.isEmpty) {
       do {
@@ -314,7 +314,8 @@ class _MockStdout implements Stdout {
   }
 
   @override
-  void writeln([Object object = ""]) {
+  void writeln([Object? object]) {
+    object ??= '';
     write(object);
     write("\n");
   }

--- a/test/e2e_test.dart
+++ b/test/e2e_test.dart
@@ -1,5 +1,3 @@
-library linkcheck.e2e_test;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/test/glob_test.dart
+++ b/test/glob_test.dart
@@ -8,7 +8,7 @@ void main() {
     var sink = StreamController<Map<String, Object>>();
     var options = FetchOptions(sink);
     Uri uri = Uri.parse("http://localhost:4000/");
-    options.addHostGlobs([uri.toString() + "**"]);
+    options.addHostGlobs(["$uri**"]);
     expect(options.matchesAsInternal(uri), isTrue);
     sink.close();
   });
@@ -17,7 +17,7 @@ void main() {
     var sink = StreamController<Map<String, Object>>();
     var options = FetchOptions(sink);
     Uri uri = Uri.parse("http://localhost:4000/guides");
-    options.addHostGlobs([uri.toString() + "**"]);
+    options.addHostGlobs(["$uri**"]);
     expect(options.matchesAsInternal(uri), isTrue);
     sink.close();
   });

--- a/test/glob_test.dart
+++ b/test/glob_test.dart
@@ -1,3 +1,4 @@
+import 'package:linkcheck/src/worker/worker.dart';
 import 'package:test/test.dart';
 
 import 'dart:async';
@@ -5,7 +6,7 @@ import 'package:linkcheck/src/worker/fetch_options.dart';
 
 void main() {
   test("parses simple example", () {
-    var sink = StreamController<Map<String, Object>>();
+    var sink = StreamController<WorkerTask>();
     var options = FetchOptions(sink);
     Uri uri = Uri.parse("http://localhost:4000/");
     options.addHostGlobs(["$uri**"]);
@@ -14,7 +15,7 @@ void main() {
   });
 
   test("parses localhost:4000/guides", () {
-    var sink = StreamController<Map<String, Object>>();
+    var sink = StreamController<WorkerTask>();
     var options = FetchOptions(sink);
     Uri uri = Uri.parse("http://localhost:4000/guides");
     options.addHostGlobs(["$uri**"]);
@@ -23,7 +24,7 @@ void main() {
   });
 
   test("parses localhost:4000/guides/", () {
-    var sink = StreamController<Map<String, Object>>();
+    var sink = StreamController<WorkerTask>();
     var options = FetchOptions(sink);
     Uri uri = Uri.parse("http://localhost:4000/guides/");
     options.addHostGlobs(["http://localhost:4000/guides**"]);

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -11,7 +11,7 @@ void main(List<String> args) {
 
 @DefaultTask()
 @Task()
-Future test() => TestRunner().testAsync();
+Future<dynamic> test() => TestRunner().testAsync();
 
 @Task()
 void clean() => defaultClean();


### PR DESCRIPTION
Linkcheck needs to migrate to support sound null safety to allow developers with a Dart 3 dev SDK to run it.

This PR also moves away from a from-to-map based solution for passing messages between isolates. It was a bit messy once migrated to null safety, and the objects can be passed directly instead. To maintain the same system where workers stay alive due to their HTTP connections, messages are now specified within a `WorkerTask` with a `WorkerVerb` enum specifying its type. Messages are shared when immutable and automatically copied when not. I didn't run any benchmarks, but I imagine it may result in some speed ups too due to avoiding some unnecessary object constructions as well as simpler comparisons.

\cc @domesticmouse and @khanhnwin As this will be needed for dart-lang/site-www (sooner) and flutter/website (later)