### PR TITLE
Fix usage of standalone pub tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
       - run: dart --version
-      - run: pub get
+      - run: dart pub get
       - run: dart analyze --fatal-warnings .
       - run: dart format --set-exit-if-changed .
       - run: dart run test -x integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
       - run: dart --version
-      - run: pub get
-      - run: pub global activate grinder
+      - run: dart pub get
+      - run: dart pub global activate grinder
       - run: echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
       - name: Package and publish
         run: grind pkg-github-all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM dart
 
-RUN pub global activate linkcheck
+RUN dart pub global activate linkcheck
 
 ENTRYPOINT ["/root/.pub-cache/bin/linkcheck"]

--- a/GithubActionDockerfile
+++ b/GithubActionDockerfile
@@ -1,6 +1,6 @@
 FROM google/dart
 
-RUN pub global activate linkcheck
+RUN dart pub global activate linkcheck
 COPY github_action_entrypoint.sh /entrypoint.sh 
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $ brew install dart
 Once Dart is installed, run:
 
 ```
-$ pub global activate linkcheck
+$ dart pub global activate linkcheck
 ```
 
 Pub installs executables into `~/.pub-cache/bin`, which may not be on your path.

--- a/linkcheck-skip-file.txt
+++ b/linkcheck-skip-file.txt
@@ -1,4 +1,0 @@
-journals(?!\/msl\/).*articles
-journals(?!\/msl\/).*issues
-books(?!\/esiam\/).*
-content/serial-article-files/.*

--- a/linkcheck-skip-file.txt
+++ b/linkcheck-skip-file.txt
@@ -1,0 +1,4 @@
+journals(?!\/msl\/).*articles
+journals(?!\/msl\/).*issues
+books(?!\/esiam\/).*
+content/serial-article-files/.*


### PR DESCRIPTION
The `pub` tool has moved to `dart pub` (https://github.com/dart-lang/sdk/issues/46100)

This pr fixes build error by adding a `dart` prefix before all `pub commands`