### PR TITLE
Fix SDK constraint and update dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: "direct dev"
     description:
       name: cli_pkg
-      sha256: b564e39edc96126238c2f0371b2ef0420fc2633e6e0780c9eadd6d1ec21cbb96
+      sha256: ca6d4a3b57fbc1bace95ca8090ca7e577c29f616d99634cd17fd1af2f983213f
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.9"
   cli_util:
     dependency: transitive
     description:
@@ -221,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: "323b7c70073cccf6b9b8d8b334be418a3293cfb612a560dc2737160a37bf61bd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.6"
   json_annotation:
     dependency: transitive
     description:
@@ -253,10 +253,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.14"
   meta:
     dependency: "direct main"
     description:
@@ -345,6 +345,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  retry:
+    dependency: transitive
+    description:
+      name: retry
+      sha256: "45dfeebaf095b606fdb9dbfb4c114cc204449bc274783b452658365e03afdbab"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description: >-
 repository: https://github.com/filiph/linkcheck
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
   args: ^2.2.0
@@ -25,7 +25,7 @@ dev_dependencies:
   lints: ^2.0.1
   dhttpd: ^4.0.0
   test: ^1.22.1
-  cli_pkg: ^2.1.6
+  cli_pkg: ^2.1.7
   grinder: ^0.9.2
 
 executables:


### PR DESCRIPTION
pub.dev and PANA do not yet handle an upper SDK constraint of `<4.0.0` properly, marking such a package as "Dart 2 incompatible". This PR reverts to a `<3.0.0` upper SDK constraint. It also updates the minimum `cli_pkg` constraint to `2.1.7` which includes a security fix.

Some fixes have been made but others are still missing (https://github.com/dart-lang/pub-dev/issues/6305).