### PR TITLE
Update for a 3.0.0 null-safe release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.0-dev
+## 3.0.0
 
 - Require Dart 2.18 and support Dart 3
 - Rename library to `linkcheck` instead of `linkcheck.run`

--- a/lib/linkcheck.dart
+++ b/lib/linkcheck.dart
@@ -25,7 +25,7 @@ const hostsFlag = 'hosts';
 const inputFlag = 'input-file';
 const redirectFlag = 'show-redirects';
 const skipFlag = 'skip-file';
-const version = '3.0.0-dev';
+const version = '3.0.0';
 const versionFlag = 'version';
 final _portOnlyRegExp = RegExp(r'^:\d+$');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linkcheck
-version: 3.0.0-dev # Don't forget to update in lib/linkcheck.dart, too.
+version: 3.0.0 # Don't forget to update in lib/linkcheck.dart, too.
 
 description: >-
   A very fast link-checker. Crawls sites and checks integrity of links


### PR DESCRIPTION
I haven't been able to find time yet to work on other post-null safety and immutable cleanup, but I think the package is in a good spot for a release, especially with more people beginning to run SDKs which are incapable of running packages not supporting null safety.

I've tested on both `dart-lang/site-www` and `flutter/website` and functionality and performance are both where I'd expect them to be.