### PR TITLE
Updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ All bellow usage are valid running on container too.
 #### Usage (github action)
 
 ```
-uses: filiph/linkcheck@v2.0.23
+uses: filiph/linkcheck@2.0.23
   with:
     arguments: <URL>
 ```


### PR DESCRIPTION
Corrected version of GH action. No `v` needed. Tripped me up when I was copy/pasting it.